### PR TITLE
Add Best Paper Award news to homepage

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -7,6 +7,10 @@ redirect_from:
   - /about.html
 ---
 
+News
+======
+- We won **Best Paper Award** in [Visual Art, Generative AI, and the Legal/Ethical Dilemma Workshop @ WACV 2026](https://sites.google.com/view/vagaled-wacv2026/) for our paper titled *"EZBlender: Efficient 3D Editing with Plan-and-React Agent"*!
+
 This is the front page of a website that is powered by the [Academic Pages template](https://github.com/academicpages/academicpages.github.io) and hosted on GitHub pages. [GitHub pages](https://pages.github.com) is a free service in which websites are built and hosted from code and data stored in a GitHub repository, automatically updating when a new commit is made to the repository. This template was forked from the [Minimal Mistakes Jekyll Theme](https://mmistakes.github.io/minimal-mistakes/) created by Michael Rose, and then extended to support the kinds of content that academics have: publications, talks, teaching, a portfolio, blog posts, and a dynamically-generated CV. You can fork [this template](https://github.com/academicpages/academicpages.github.io) right now, modify the configuration and markdown files, add your own PDFs and other content, and have your own site for free, with no ads!
 
 A data-driven personal website


### PR DESCRIPTION
## Summary
- Add a News section to the homepage announcing Best Paper Award at VAGALED Workshop @ WACV 2026 for the paper "EZBlender: Efficient 3D Editing with Plan-and-React Agent"

## Test plan
- [ ] Verify the news item renders correctly on the homepage at localhost:4000

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk content-only change to the homepage markdown; no code paths, builds, or data handling are affected.
> 
> **Overview**
> Adds a new **News** section to the homepage (`_pages/about.md`) announcing a *Best Paper Award* at the VAGALED Workshop @ WACV 2026 for the paper "EZBlender: Efficient 3D Editing with Plan-and-React Agent", including a link to the workshop site.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dedd87f9045661ac11ddb0f0d04f0102f31ce652. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->