### PR TITLE
Add Best Paper Award news to homepage

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -8,6 +8,10 @@ redirect_from:
   - /about.html
 ---
 
+News
+======
+- We won **Best Paper Award** in [Visual Art, Generative AI, and the Legal/Ethical Dilemma Workshop @ WACV 2026](https://sites.google.com/view/vagaled-wacv2026/) for our paper titled *"EZBlender: Efficient 3D Editing with Plan-and-React Agent"*!
+
 I am a seasoned scientist & engineer working in the field of Machine Learning Systems with a primary focus on the optimization of large-scale distributed training and inference systems for foundation models and large language models (LLMs). Distinct from many other ML Systems researchers, my work also extends into core modeling research. My core modeling research mainly focuses on efficient AI—particularly LLM compression, knowledge distillation, LLM post-training methodologies, Agentic Reinforcement Learning and Vision-Language Models (VLM). Some of the research findings are published in *EMNLP, ICCV, ECCV, WACV, ICML and NeurIPS etc.* 
 
 **Some of the representative ML Systems that I was involved in the development phase** including [DeepSpeed](https://github.com/deepspeedai/DeepSpeed), one of the most popular OSS LLM distributed training library (code maintainer and TSC Committer); [fmchisel](https://github.com/linkedin/fmchisel), the state-of-the-art Foundation Models Optimization research library (e.g. knowledge distillation,compression and quantization etc); and [Liger Kernel](https://github.com/linkedin/Liger-Kernel) (Kudos to Byron Hsu and Yun Dai et al for leading the work). 

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -8,15 +8,14 @@ redirect_from:
   - /about.html
 ---
 
-News
-======
-- We won **Best Paper Award** in [Visual Art, Generative AI, and the Legal/Ethical Dilemma Workshop @ WACV 2026](https://sites.google.com/view/vagaled-wacv2026/) for our paper titled *"EZBlender: Efficient 3D Editing with Plan-and-React Agent"*!
-
 I am a seasoned scientist & engineer working in the field of Machine Learning Systems with a primary focus on the optimization of large-scale distributed training and inference systems for foundation models and large language models (LLMs). Distinct from many other ML Systems researchers, my work also extends into core modeling research. My core modeling research mainly focuses on efficient AI—particularly LLM compression, knowledge distillation, LLM post-training methodologies, Agentic Reinforcement Learning and Vision-Language Models (VLM). Some of the research findings are published in *EMNLP, ICCV, ECCV, WACV, ICML and NeurIPS etc.* 
 
 **Some of the representative ML Systems that I was involved in the development phase** including [DeepSpeed](https://github.com/deepspeedai/DeepSpeed), one of the most popular OSS LLM distributed training library (code maintainer and TSC Committer); [fmchisel](https://github.com/linkedin/fmchisel), the state-of-the-art Foundation Models Optimization research library (e.g. knowledge distillation,compression and quantization etc); and [Liger Kernel](https://github.com/linkedin/Liger-Kernel) (Kudos to Byron Hsu and Yun Dai et al for leading the work). 
 
 In the corporate world, I am Senior Manager/Senior Staff Research Scientist leading the Foundational AI algorithms organization at LinkedIn (subsidary of Microsoft). Previously I worked at AWS AI organization at Amazon, where I was leading the SageMaker Applied Science Team contributing to LLM Inference/Distributed Training and Evaluation Services. I was also the Tech Lead Manager/Staff Software Engineer at Google[X]/Google Research, where I was building up the machine learning team for the Moonshot project [Chorus](https://x.company/projects/chorus/) and engaged in AIDA project building [coding agent using LLM](https://x.company/projects/aida/) (now part of Gemini). I was also involved in PaLM model development work across Alphabet. Before that I was Staff Research Scientist at Apple, where I lead the development of ML Algorithms for [Sleep Apnea Detection on Apple Watch](https://www.apple.com/health/pdf/sleep-apnea/Sleep_Apnea_Notifications_on_Apple_Watch_September_2024.pdf). 
+
+## News
+- We won **Best Paper Award** in [Visual Art, Generative AI, and the Legal/Ethical Dilemma Workshop @ WACV 2026](https://sites.google.com/view/vagaled-wacv2026/) for our paper titled *"EZBlender: Efficient 3D Editing with Plan-and-React Agent"*!
 
 <!--# Selected Experiences-->
 ## Talks and Tutorials 


### PR DESCRIPTION
## Summary
- Add a News section to the homepage announcing Best Paper Award at VAGALED Workshop @ WACV 2026 for the paper "EZBlender: Efficient 3D Editing with Plan-and-React Agent"

## Test plan
- [ ] Verify the news item renders correctly on the homepage at localhost:4000

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: markdown-only content change with no code, data handling, or behavioral impact beyond rendering the new section.
> 
> **Overview**
> Adds a **new `News` section** at the top of `_pages/about.md` (homepage) with a single bullet announcing a **Best Paper Award** at *VAGALED Workshop @ WACV 2026*, including an external link and paper title.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15f6c2de68f62d23313106fbbb864e6ffa645c40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->