### PR TITLE
Add ICML 2026 S-SPPO paper to publications

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -106,6 +106,18 @@ In the corporate world, I am Senior Manager/Senior Staff Research Scientist lead
 
 <div class="pub-entry">
   <div class="pub-img">
+    <img src="/images/publications/icml2026_sppo.png" alt="S-SPPO">
+  </div>
+  <div class="pub-text">
+    <div class="pub-title"><a href="https://icml.cc/virtual/2026/poster/61018">S-SPPO: Semantic-Calibrated Self-Play Preference Optimization</a></div>
+    <div class="pub-authors">Xiwen Chen, Wenhui Zhu, Jingjing Wang, Peijie Qiu, <strong>Zhipeng Wang</strong>#, Huayu Li, ZhengXiao He, Xuanzhao Dong, Prayag Tiwari, Mingkun Xu, Yujian Xiong, Feng Luo, Abolfazl Razi, Brendan Rappazzo, Anderson Schneider, Yuriy Nevmyvaka</div>
+    <div class="pub-venue">ICML 2026 (# corresponding author)</div>
+    <div class="pub-links">[<a href="https://icml.cc/virtual/2026/poster/61018">Paper</a>]</div>
+  </div>
+</div>
+
+<div class="pub-entry">
+  <div class="pub-img">
     <img src="/images/publications/icml2025_liger_kernel.png" alt="Liger Kernel">
   </div>
   <div class="pub-text">


### PR DESCRIPTION
## Summary
- Adds the ICML 2026 paper *S-SPPO: Semantic-Calibrated Self-Play Preference Optimization* to the Selected Recent Publications section in `_pages/about.md`, following the existing `pub-entry` format.
- Marks Zhipeng Wang as corresponding author (#) and links to the ICML virtual page (https://icml.cc/virtual/2026/poster/61018).
- References `/images/publications/icml2026_sppo.png` as the thumbnail (image file to be added separately).

## Test plan
- [ ] Render the site locally and confirm the new entry appears between the WACV 2026 and ICML 2025 entries with correct title, author list, venue line, and Paper link.
- [ ] Add `images/publications/icml2026_sppo.png` so the thumbnail loads (until then the alt text "S-SPPO" will display).

🤖 Generated with [Claude Code](https://claude.com/claude-code)