### PR TITLE
Update MLSys 2026 publication link to OpenReview

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -205,10 +205,10 @@ In the corporate world, I am Senior Manager/Senior Staff Research Scientist lead
     <img src="/images/publications/scaling_up_slm.png" alt="Scaling Up SLM">
   </div>
   <div class="pub-text">
-    <div class="pub-title"><a href="https://arxiv.org/abs/2510.22101">Scaling Up Efficient Small Language Models Serving and Deployment for Semantic Job Search</a></div>
+    <div class="pub-title"><a href="https://openreview.net/pdf?id=re82zZczHj">Scaling Up Efficient Small Language Models Serving and Deployment for Semantic Job Search</a></div>
     <div class="pub-authors">Kayhan Behdin, Qingquan Song, Sriram Vasudevan, Jian Sheng, Xiaojing Ma, Z Zhou, Chuanrui Zhu, Guoyao Li, Chanh Nguyen, Sayan Ghosh, Hejian Sang, Ata Fatahi Baarzi, Sundara Raman Ramachandran, Xiaoqing Wang, Qing Lan, Qi Guo, Caleb Johnson, <strong>Zhipeng Wang</strong>*, Fedor Borisyuk</div>
     <div class="pub-venue">MLSys 2026 (* Corresponding author)</div>
-    <div class="pub-links">[<a href="https://arxiv.org/abs/2510.22101">Paper</a>]</div>
+    <div class="pub-links">[<a href="https://openreview.net/pdf?id=re82zZczHj">Paper</a>]</div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Replace the arXiv link with the OpenReview PDF link for the MLSys 2026 paper "Scaling Up Efficient Small Language Models Serving and Deployment for Semantic Job Search"
- Updates both the title link and the [Paper] link

## Test plan
- [ ] Verify both links on the rendered home page point to https://openreview.net/pdf?id=re82zZczHj

🤖 Generated with [Claude Code](https://claude.com/claude-code)