### PR TITLE
Add CAIS abbreviation to ACM AI and Agentic Systems venue label

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -98,7 +98,7 @@ In the corporate world, I am Senior Manager/Senior Staff Research Scientist lead
   <div class="pub-text">
     <div class="pub-title"><a href="https://dl.acm.org/doi/10.1145/3786335.3813134">Robust Batch-Level Query Routing for Large Language Models under Cost and Capacity Constraints</a></div>
     <div class="pub-authors">Jelena Markovic-Voronov, Kayhan Behdin, Yuanda Xu, Zhengze Zhou, <strong>Zhipeng Wang</strong>#, Rahul Mazumder</div>
-    <div class="pub-venue">ACM Conference on AI and Agentic Systems 2026 (# corresponding author)</div>
+    <div class="pub-venue">ACM Conference on AI and Agentic Systems(CAIS) 2026 (# corresponding author)</div>
     <div class="pub-links">[<a href="https://dl.acm.org/doi/10.1145/3786335.3813134">Paper</a>]</div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Append the `(CAIS)` abbreviation after "ACM Conference on AI and Agentic Systems" in the venue line for the query routing paper

## Test plan
- [x] Verify the rendered home page shows "ACM Conference on AI and Agentic Systems(CAIS) 2026" on the CAIS entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)