### PR TITLE
Add Oral Presentation highlight to MLSys 2026 entry

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -244,6 +244,7 @@ In the corporate world, I am Senior Manager/Senior Staff Research Scientist lead
     <div class="pub-title"><a href="https://openreview.net/pdf?id=re82zZczHj">Scaling Up Efficient Small Language Models Serving and Deployment for Semantic Job Search</a></div>
     <div class="pub-authors">Kayhan Behdin, Qingquan Song, Sriram Vasudevan, Jian Sheng, Xiaojing Ma, Z Zhou, Chuanrui Zhu, Guoyao Li, Chanh Nguyen, Sayan Ghosh, Hejian Sang, Ata Fatahi Baarzi, Sundara Raman Ramachandran, Xiaoqing Wang, Qing Lan, Qi Guo, Caleb Johnson, <strong>Zhipeng Wang</strong>*, Fedor Borisyuk</div>
     <div class="pub-venue">MLSys 2026 (* Corresponding author)</div>
+    <div class="pub-highlight">Oral Presentation</div>
     <div class="pub-links">[<a href="https://openreview.net/pdf?id=re82zZczHj">Paper</a>]</div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Add the `Oral Presentation` highlight line to the MLSys 2026 publication entry, matching the EMNLP 2025 styling

## Test plan
- [x] Verify the rendered home page shows the "Oral Presentation" badge on the MLSys 2026 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)